### PR TITLE
Improved handling of packages without scripts.

### DIFF
--- a/bro-pkg
+++ b/bro-pkg
@@ -941,6 +941,10 @@ def cmd_load(manager, args, config):
             print('Failed to load "{}": no such package installed'.format(name))
             continue
 
+        if not manager.has_scripts(ipkg):
+            print('The package "{}" does not contain scripts to load.'.format(name))
+            continue
+
         name = ipkg.package.qualified_name()
         load_error = manager.load(name)
 
@@ -956,6 +960,10 @@ def cmd_unload(manager, args, config):
 
         if not ipkg:
             print('Failed to unload "{}": no such package installed'.format(name))
+            continue
+
+        if not manager.has_scripts(ipkg):
+            print('The package "{}" does not contain scripts to unload.'.format(name))
             continue
 
         name = ipkg.package.qualified_name()


### PR DESCRIPTION
If `load` is used for a package without `script_dir` bro-pkg returns something like:
> ```Failed to load "bro/j-gras/my-package": no __load__.bro within package script_dir```

As this is intended I would prefer another message in this case (e.g. as suggested by the patch).
