### PR TITLE
Fix imports for python3

### DIFF
--- a/bro-pkg
+++ b/bro-pkg
@@ -19,7 +19,10 @@ import filecmp
 import shutil
 import subprocess
 
-from backports import configparser
+try:
+    from backports import configparser
+except ImportError as err:
+    import configparser
 
 import bropkg
 

--- a/bropkg/manager.py
+++ b/bropkg/manager.py
@@ -11,7 +11,11 @@ import filecmp
 import tarfile
 import subprocess
 
-from backports import configparser
+try:
+    from backports import configparser
+except ImportError as err:
+    import configparser
+
 import git
 import semantic_version as semver
 

--- a/bropkg/source.py
+++ b/bropkg/source.py
@@ -10,7 +10,10 @@ import os
 import shutil
 import git
 
-from backports import configparser
+try:
+    from backports import configparser
+except ImportError as err:
+    import configparser
 
 from . import LOG
 from .package import (


### PR DESCRIPTION
This PR fixes import issues for configparser when building the tool with python3.