### PR TITLE
Version numbers should be sorted naturally

### DIFF
--- a/bropkg/manager.py
+++ b/bropkg/manager.py
@@ -1940,7 +1940,7 @@ def _get_version_tags(clone):
         else:
             tags.append(tag)
 
-    return sorted(tags)
+    return sorted(tags, key=semver.Version.coerce)
 
 
 def _get_branch_names(clone):


### PR DESCRIPTION
For packages with multiple versions/tags (e.g., https://github.com/ncsa/bro-doctor) bro-pkg may choose a version which is not actually the latest version due to alphabetical sorting rather than 'natural' sorting. For example, tag '1.9.0' is considered newer than tag '1.10.0'. This results in the incorrect 'latest' package version being selected in commands such as 'install' and 'info'. 

@JustinAzoff came up with a one-line fix to sort by version numbers.