### PR TITLE
Add JSON output as option to 'info' command.

### DIFF
--- a/bro-pkg
+++ b/bro-pkg
@@ -1188,33 +1188,65 @@ def cmd_info(manager, args, config):
                 info.metadata_version))
 
         if len(info.metadata) == 0:
-            if args.json:
-                pkginfo[name]['metadata'][info.metadata_version] = dict()
-            else:
+            if args.json != True:
                 print('\t\t<empty metadata file>')
         else:
-            for key, value in sorted(info.metadata.items()):
-                if args.json:
-                    if key == 'depends':
-                        pkginfo[name]['metadata'][info.metadata_version]\
-                            ['depends'] = dict()
-                        deps = value.split('\n');
-                        for i in range(1,len(deps)):
-                            deplist = deps[i].split(' ')
-                            pkginfo[name]['metadata'][info.metadata_version]\
-                                ['depends'][deplist[0]] = deplist[1];
-                    else:
-                        pkginfo[name]['metadata'][info.metadata_version][key]=\
-                            value
-                else:
+            if args.json:
+                _fill_metadata_version(
+                    pkginfo[name]['metadata'][info.metadata_version],
+                    info.metadata)
+            else:
+                for key, value in sorted(info.metadata.items()):
                     value = value.replace('\n', '\n\t\t\t')
                     print('\t\t{} = {}'.format(key, value))
+
+        # If --json and --allvers given, check for multiple versions and
+        # add the metadata for each version to the pkginfo.
+        if args.json and args.allvers:
+            for vers in info.versions:
+                # Skip the version that was already processed
+                if vers != info.metadata_version:
+                    info2 = manager.info(name, 
+                                         vers, 
+                                         prefer_installed=(args.nolocal!=True))
+                    pkginfo[name]['metadata'][info2.metadata_version] = dict()
+                    _fill_metadata_version(
+                        pkginfo[name]['metadata'][info2.metadata_version],
+                        info2.metadata);
 
         if args.json != True:
             print()
 
     if args.json:
         print(json.dumps(pkginfo, indent=args.jsonpretty, sort_keys=True))
+
+
+def _fill_metadata_version(pkginfo_name_metadata_version, info_metadata):
+    """ Fill a dict with metadata information.
+
+        This helper function is called by cmd_info to fill metadata information
+        for a specific package version.
+
+    Args:
+        pkginfo_name_metadata_version (dict of str -> dict): Corresponds
+            to pkginfo[name]['metadata'][info.metadata_version] in cmd_info.
+
+        info_metadata (dict of str->str): Corresponds to info.metadata
+            in cmd_info.
+
+    Side effect: 
+        New dict entries are added to pkginfo_name_metadata_version.
+    """
+    for key, value in info_metadata.items():
+        if key == 'depends':
+            pkginfo_name_metadata_version['depends'] = dict()
+            deps = value.split('\n');
+            for i in range(1,len(deps)):
+                deplist = deps[i].split(' ')
+                pkginfo_name_metadata_version['depends'][deplist[0]]=\
+                    deplist[1];
+        else:
+            pkginfo_name_metadata_version[key]=value
 
 
 def cmd_config(manager, args, config):
@@ -1637,6 +1669,13 @@ def argparser():
         '--jsonpretty', type=int, default=None, metavar='SPACES',
         help='Optional number of spaces to indent for pretty-printed'
         ' JSON output.')
+    sub_parser.add_argument(
+        '--allvers' , action='store_true',
+        help='When outputting package information as JSON, show metadata for'
+        ' all versions. This option can be slow since remote repositories'
+        ' may be cloned multiple times. Also, installed packages will show'
+        ' metadata only for the installed version unless the --nolocal '
+        ' option is given.')
 
     # config
     sub_parser = command_parser.add_parser(

--- a/bro-pkg
+++ b/bro-pkg
@@ -18,6 +18,7 @@ import tarfile
 import filecmp
 import shutil
 import subprocess
+import json
 
 try:
     from backports import configparser
@@ -1141,38 +1142,79 @@ def cmd_info(manager, args, config):
             'error: "info --version" may only be used for a single package')
         sys.exit(1)
 
+    # Dictionary for storing package info to output as JSON
+    pkginfo = dict()
+
     for name in args.package:
         info = manager.info(name, version=args.version, prefer_installed=True)
 
         if info.package:
             name = info.package.qualified_name()
 
-        print('"{}" info:'.format(name))
+        if (args.json):
+            pkginfo[name] = dict()
+            pkginfo[name]['metadata'] = dict()
+        else:
+            print('"{}" info:'.format(name))
 
         if info.invalid_reason:
-            print('\tinvalid package: {}\n'.format(info.invalid_reason))
+            if (args.json):
+                pkginfo[name]['invalid'] = info.invalid_reason
+            else:
+                print('\tinvalid package: {}\n'.format(info.invalid_reason))
             continue
 
-        print('\turl: {}'.format(info.package.git_url))
-        print('\tversions: {}'.format(info.versions))
+        if (args.json):
+            pkginfo[name]['url'] = info.package.git_url
+            pkginfo[name]['versions'] = info.versions
+        else:
+            print('\turl: {}'.format(info.package.git_url))
+            print('\tversions: {}'.format(info.versions))
 
         if info.status:
-            print('\tinstall status:')
+            if (args.json):
+                pkginfo[name]['install_status'] = dict()
+                for key, value in sorted(info.status.__dict__.items()):
+                    pkginfo[name]['install_status'][key] = value
+            else:
+                print('\tinstall status:')
+                for key, value in sorted(info.status.__dict__.items()):
+                    print('\t\t{} = {}'.format(key, value))
 
-            for key, value in sorted(info.status.__dict__.items()):
-                print('\t\t{} = {}'.format(key, value))
-
-        print('\tmetadata (from version "{}"):'.format(
-            info.metadata_version))
+        if (args.json):
+            pkginfo[name]['metadata'][info.metadata_version] = dict()
+        else:
+            print('\tmetadata (from version "{}"):'.format(
+                info.metadata_version))
 
         if len(info.metadata) == 0:
-            print('\t\t<empty metadata file>')
+            if (args.json):
+                pkginfo[name]['metadata'][info.metadata_version] = dict()
+            else:
+                print('\t\t<empty metadata file>')
+        else:
+            for key, value in sorted(info.metadata.items()):
+                if (args.json):
+                    if (key == 'depends'):
+                        pkginfo[name]['metadata'][info.metadata_version]\
+                            ['depends'] = dict()
+                        deps = value.split('\n');
+                        for i in range(1,len(deps)):
+                            deplist = deps[i].split(' ')
+                            pkginfo[name]['metadata'][info.metadata_version]\
+                                ['depends'][deplist[0]] = deplist[1];
+                    else:
+                        pkginfo[name]['metadata'][info.metadata_version][key]=\
+                            value
+                else:
+                    value = value.replace('\n', '\n\t\t\t')
+                    print('\t\t{} = {}'.format(key, value))
 
-        for key, value in sorted(info.metadata.items()):
-            value = value.replace('\n', '\n\t\t\t')
-            print('\t\t{} = {}'.format(key, value))
-
-        print()
+        if (args.json):
+            print(json.dumps(pkginfo, False, True, True, True, None,
+                  args.jsonpretty))
+        else:
+            print()
 
 
 def cmd_config(manager, args, config):
@@ -1588,6 +1630,17 @@ def argparser():
         ' the metadata will be pulled from the installed version.  If not'
         ' installed, the latest version tag is used, or if a package has no'
         ' version tags, the "master" branch is used.')
+    sub_parser.add_argument(
+        '--nolocal', action='store_true',
+        help='Do not read information from locally installed packages.'
+        ' Instead read info from remote GitHub.')
+    sub_parser.add_argument(
+        '--json', action='store_true',
+        help='Output package information as JSON.')
+    sub_parser.add_argument(
+        '--jsonpretty', type=int, default=None, metavar='SPACES',
+        help='Optional number of spaces to indent for pretty-printed'
+        ' JSON output.')
 
     # config
     sub_parser = command_parser.add_parser(

--- a/bro-pkg
+++ b/bro-pkg
@@ -1214,8 +1214,7 @@ def cmd_info(manager, args, config):
             print()
 
     if args.json:
-        print(json.dumps(pkginfo, False, True, True, True, None,
-              args.jsonpretty))
+        print(json.dumps(pkginfo, indent=args.jsonpretty, sort_keys=True))
 
 
 def cmd_config(manager, args, config):

--- a/bro-pkg
+++ b/bro-pkg
@@ -1151,20 +1151,20 @@ def cmd_info(manager, args, config):
         if info.package:
             name = info.package.qualified_name()
 
-        if (args.json):
+        if args.json:
             pkginfo[name] = dict()
             pkginfo[name]['metadata'] = dict()
         else:
             print('"{}" info:'.format(name))
 
         if info.invalid_reason:
-            if (args.json):
+            if args.json:
                 pkginfo[name]['invalid'] = info.invalid_reason
             else:
                 print('\tinvalid package: {}\n'.format(info.invalid_reason))
             continue
 
-        if (args.json):
+        if args.json:
             pkginfo[name]['url'] = info.package.git_url
             pkginfo[name]['versions'] = info.versions
         else:
@@ -1172,7 +1172,7 @@ def cmd_info(manager, args, config):
             print('\tversions: {}'.format(info.versions))
 
         if info.status:
-            if (args.json):
+            if args.json:
                 pkginfo[name]['install_status'] = dict()
                 for key, value in sorted(info.status.__dict__.items()):
                     pkginfo[name]['install_status'][key] = value
@@ -1181,21 +1181,21 @@ def cmd_info(manager, args, config):
                 for key, value in sorted(info.status.__dict__.items()):
                     print('\t\t{} = {}'.format(key, value))
 
-        if (args.json):
+        if args.json:
             pkginfo[name]['metadata'][info.metadata_version] = dict()
         else:
             print('\tmetadata (from version "{}"):'.format(
                 info.metadata_version))
 
         if len(info.metadata) == 0:
-            if (args.json):
+            if args.json:
                 pkginfo[name]['metadata'][info.metadata_version] = dict()
             else:
                 print('\t\t<empty metadata file>')
         else:
             for key, value in sorted(info.metadata.items()):
-                if (args.json):
-                    if (key == 'depends'):
+                if args.json:
+                    if key == 'depends':
                         pkginfo[name]['metadata'][info.metadata_version]\
                             ['depends'] = dict()
                         deps = value.split('\n');
@@ -1210,11 +1210,12 @@ def cmd_info(manager, args, config):
                     value = value.replace('\n', '\n\t\t\t')
                     print('\t\t{} = {}'.format(key, value))
 
-        if (args.json):
-            print(json.dumps(pkginfo, False, True, True, True, None,
-                  args.jsonpretty))
-        else:
+        if args.json != True:
             print()
+
+    if args.json:
+        print(json.dumps(pkginfo, False, True, True, True, None,
+              args.jsonpretty))
 
 
 def cmd_config(manager, args, config):
@@ -1630,10 +1631,6 @@ def argparser():
         ' the metadata will be pulled from the installed version.  If not'
         ' installed, the latest version tag is used, or if a package has no'
         ' version tags, the "master" branch is used.')
-    sub_parser.add_argument(
-        '--nolocal', action='store_true',
-        help='Do not read information from locally installed packages.'
-        ' Instead read info from remote GitHub.')
     sub_parser.add_argument(
         '--json', action='store_true',
         help='Output package information as JSON.')


### PR DESCRIPTION
Add command line options '--json' and '--jsonpretty' for the 'info' command to output results as JSON. This may require some tweaking after I test the 'info' command with every current bro-pkg package to verify correct output.