### PR TITLE
Add btest as a requirement

### DIFF
--- a/requirements.doc.txt
+++ b/requirements.doc.txt
@@ -4,3 +4,4 @@ GitPython
 semantic_version
 configparser
 sphinx_rtd_theme
+btest


### PR DESCRIPTION
I was running through an exercise of packaging `bro-pkg` as a deb this morning and noticed that `requirements.doc.txt` doesn't mention btest as a requirement, but `doc/quickstart.rst` does.